### PR TITLE
Music Team Page

### DIFF
--- a/_includes/music_team_info.html
+++ b/_includes/music_team_info.html
@@ -1,0 +1,9 @@
+<p>Please arrive at {% if include.service == "morning" %}08:45{% else %}15:45{% endif %} to open the Bible and pray together, set up and
+  practise.</p>
+
+<h2>Gospel Shape</h2>
+<p>Bible passage: <strong><span id="bible-passage-{{include.service}}"></span></strong></p>
+<div id="gospel-shape-{{include.service}}"></div>
+
+<h2>Songs and Running Order</h2>
+<ul id="running-order-{{include.service}}" class="running-order"></ul>

--- a/_layouts/musicteam.html
+++ b/_layouts/musicteam.html
@@ -1,0 +1,30 @@
+---
+layout: default
+---
+{% include hero.html id="music-team-hero" overlayCaption=page.overlayCaption mainImage=page.mainImage mobileImage=page.mobileImage textClass="left bottom"%}
+
+<section class="intro wider">
+  <div class="text">
+    {{ content }}
+  </div>
+</section>
+
+<section class="music-team-service dark">
+  <h1>Morning Service</h1>
+  <div class="information">
+    {% include music_team_info.html service="morning" %}
+  </div>
+</section>
+
+<section class="music-team-service">
+  <h1>Evening Service</h1>
+  <div class="information">
+    {% include music_team_info.html service="evening" %}
+  </div>
+</section>
+
+<script type="text/javascript" src="/assets/javascript/music_team_info_import.js"></script>
+<script type="text/javascript"
+  src="https://spreadsheets.google.com/feeds/cells/{{ site.music_team_info_google_sheet.id }}/{{ site.music_team_info_google_sheet.morning_sheet_number }}/public/values?alt=json-in-script&callback=onResponseMorning"></script>
+<script type="text/javascript"
+  src="https://spreadsheets.google.com/feeds/cells/{{ site.music_team_info_google_sheet.id }}/{{ site.music_team_info_google_sheet.evening_sheet_number }}/public/values?alt=json-in-script&callback=onResponseEvening"></script>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1259,6 +1259,11 @@ section.dark {
   color: var(--light-colour);
 }
 
+section.dark .button {
+  color: var(--dark-colour);
+  background-color: var(--light-colour);
+}
+
 section.image-right {
   grid-template-areas: ". text text text text text . image image image image image image image";
 }
@@ -3146,3 +3151,46 @@ section.london-living .episode .media .video .placeholder {
   text-align: center;
 }
 
+section.music-team-service {
+  grid-template-areas: ". title title title title title title title title title title title title ."
+  ". information information information information information information information information information information information information .";
+}
+
+.music-team-service > h1 {
+  grid-area: title;
+}
+
+.music-team-service .information {
+  grid-area: information;
+  font-size: 1em;
+}
+
+.music-team-service h2 {
+  margin-bottom: 0.2em;
+}
+
+.music-team-service ul.running-order {
+  list-style-type:none;
+  padding: 0;
+  margin: 0 0 1em;
+}
+
+.music-team-service ul.running-order li.non-song {
+  font-weight: 200;
+  font-size: 0.9em;
+}
+
+.music-team-service ul.running-order li.non-song.confession {
+  font-style: italic;
+}
+
+.music-team-service ul.running-order li.song {
+  font-weight: 400;
+  font-size: 1.3em;
+}
+
+.music-team-service ul.running-order li.viewer {
+  background-color: rgba(0.7, 0.7, 0.7, 0.25);
+  padding: 1em;
+  margin: 0.5em 0;
+}

--- a/assets/javascript/music_team_info_import.js
+++ b/assets/javascript/music_team_info_import.js
@@ -1,0 +1,170 @@
+const songItemPattern = /> (.*)/;
+const confessionPattern = /Confession: (\d+)/;
+
+const biblePassageElements = {
+  morning: document.getElementById("bible-passage-morning"),
+  evening: document.getElementById("bible-passage-evening")
+};
+const gospelShapeElements = {
+  morning: document.getElementById("gospel-shape-morning"),
+  evening: document.getElementById("gospel-shape-evening")
+};
+const runningOrderElements = {
+  morning: document.getElementById("running-order-morning"),
+  evening: document.getElementById("running-order-evening")
+};
+
+const confessionTextViewers = {
+  morning: document.createElement("li"),
+  evening: document.createElement("li")
+};
+confessionTextViewers.morning.classList.add("viewer");
+confessionTextViewers.evening.classList.add("viewer");
+confessionTextViewers.morning.style.display = "none";
+confessionTextViewers.evening.style.display = "none";
+
+const runningOrderItems = { morning: [], evening: [] };
+
+const showLyricsViewers = { morning: [], evening: [] };
+const hideLyricsViewers = { morning: [], evening: [] };
+const lyricsViewers = { morning: [], evening: [] };
+
+function setConfessionText(confessionText, service) {
+  confessionTextViewers[service].innerHTML = `${confessionText.replace(
+    /\n/g,
+    "<br>"
+  )}<br><a href="javascript:void(0)" class="hide" onclick="hideConfessionText('${service}');return false;">(hide)</a>`;
+}
+
+function showConfessionText(service) {
+  confessionTextViewers[service].parentElement.scrollIntoView(true, {
+    behavior: "smooth"
+  });
+  confessionTextViewers[service].style.display = "block";
+}
+
+function hideConfessionText(service) {
+  confessionTextViewers[service].style.display = "none";
+}
+
+function setBiblePassage(biblePassage, service) {
+  biblePassageElements[service].textContent = biblePassage;
+}
+
+function setGospelShape(gospelShape, service) {
+  gospelShape.split("\n\n").forEach(textItem => {
+    const textItemMatches = textItem.match(/(\w+): (.+)/);
+    const newGospelShapeItem = document.createElement("p");
+    newGospelShapeItem.innerHTML = textItemMatches
+      ? `<strong>${textItemMatches[1]}</strong>` + `: ${textItemMatches[2]}`
+      : textItem;
+    gospelShapeElements[service].appendChild(newGospelShapeItem);
+  });
+}
+
+function addLyricsViewerLiElement(songLyrics, index, service) {
+  const newLyricsViewerElement = document.createElement("li");
+  newLyricsViewerElement.classList.add("viewer");
+  newLyricsViewerElement.style.display = "none";
+  hideLyricsViewers[service].push(() => {
+    newLyricsViewerElement.parentElement.scrollIntoView(true, {
+      behavior: "smooth"
+    });
+    newLyricsViewerElement.style.display = "none";
+  });
+  showLyricsViewers[service].push(() => {
+    newLyricsViewerElement.style.display = "block";
+  });
+  newLyricsViewerElement.innerHTML = `${songLyrics.replace(
+    /\n/g,
+    "<br>"
+  )}<br><br><a href="javascript:void(0)" class="hide" onclick="hideLyricsViewers['${service}'][${index}]();return false;">(hide)</a>`;
+  lyricsViewers[service].push(newLyricsViewerElement);
+}
+
+function createSongLiElement(songTitle, songIndex, service) {
+  const newSongElement = document.createElement("li");
+  newSongElement.className = "song-item";
+  newSongElement.innerHTML = `${songTitle} <a href="javascript:void(0)" onclick="showLyricsViewers['${service}'][${songIndex}]();return false;">(see lyrics)</a>`;
+  newSongElement.append(lyricsViewers[service][songIndex]);
+  return newSongElement;
+}
+
+function createNonSongLiElement(item, isConfession, service) {
+  const newNonSongElement = document.createElement("li");
+  newNonSongElement.classList.add("non-song");
+  newNonSongElement.innerHTML = isConfession
+    ? `${item} <a href="javascript:void(0)" onclick="showConfessionText('${service}');return false;">(read this)</a>`
+    : item;
+  if (isConfession) {
+    newNonSongElement.classList.add("confession");
+    newNonSongElement.append(confessionTextViewers[service]);
+  }
+  return newNonSongElement;
+}
+
+function setRunningOrder(service) {
+  let songIndex = 0;
+  runningOrderItems[service].forEach(textItem => {
+    console.log(textItem);
+    if (textItem.match(songItemPattern)) {
+      runningOrderElements[service].appendChild(
+        createSongLiElement(
+          textItem.match(songItemPattern)[1],
+          songIndex,
+          service
+        )
+      );
+      songIndex++;
+    } else if (textItem.match(confessionPattern)) {
+      runningOrderElements[service].appendChild(
+        createNonSongLiElement(textItem, true, service)
+      );
+    } else {
+      runningOrderElements[service].appendChild(
+        createNonSongLiElement(textItem, false, service)
+      );
+    }
+  });
+}
+
+const dataCellSetters = {
+  A2: setBiblePassage,
+  C4: setGospelShape,
+  J4: setConfessionText
+};
+
+function isCellReferenceRunningOrderItem(column, row) {
+  return column === "A" && row >= 4;
+}
+
+function isCellReferenceLyrics(column, row) {
+  return "D" <= column && column < "J" && row == 4;
+}
+
+function onResponse(data, service) {
+  data.feed.entry.forEach(entry => {
+    const reference = entry.title.$t;
+    const setter = dataCellSetters[reference];
+    if (setter) {
+      setter(entry.content.$t, service);
+    } else {
+      const cellReferenceMatches = entry.title.$t.match(/([A-Z]+)(\d+)/);
+      const column = cellReferenceMatches[1];
+      const row = cellReferenceMatches[2];
+      if (isCellReferenceRunningOrderItem(column, row)) {
+        runningOrderItems[service].push(entry.content.$t);
+      } else if (isCellReferenceLyrics(column, row)) {
+        addLyricsViewerLiElement(
+          entry.content.$t,
+          column.charCodeAt(0) - "D".charCodeAt(0),
+          service
+        );
+      }
+    }
+  });
+  setRunningOrder(service);
+}
+
+const onResponseMorning = data => onResponse(data, "morning");
+const onResponseEvening = data => onResponse(data, "evening");


### PR DESCRIPTION
# Music Team Page

## Background

Every week, musicians playing at each service receive an email from Ben Slee, telling them the shape of the service, including the outline of the gospel message being preached, the songs which they will lead, and the lyrics for these songs. This is currently on [a public Google Sheet, on the first two tabs](https://docs.google.com/spreadsheets/d/1BNfhAFMDq25GHh9KiPx0IYv7ktdooDW-LIR1uLSWv2w). This is not very mobile friendly, and isn't especially visually pleasing.

## What?

I've created a page which dislays this information in what I think is a more user-friendly way. It will be accessed by going to christchurchmayfair.org/music-team and has not been added to any navigational elements, so is in effect hidden.

[You can see a live preview here at the branch build site.](https://5d49e338111e360008dba648--ccmsite.netlify.com/music-team)

**There is a related pull request on the `ccm_jekyll_site` repo.**
